### PR TITLE
Solve low accuracy with an even number of points

### DIFF
--- a/scipy/integrate/quadrature.py
+++ b/scipy/integrate/quadrature.py
@@ -346,16 +346,8 @@ def simps(y, x=None, dx=1, axis=-1, even='avg'):
         `x` is None. Default is 1.
     axis : int, optional
         Axis along which to integrate. Default is the last axis.
-    even : {'avg', 'first', 'str'}, optional
-        'avg' : Average two results:1) use the first N-2 intervals with
-                  a trapezoidal rule on the last interval and 2) use the last
-                  N-2 intervals with a trapezoidal rule on the first interval.
-
-        'first' : Use Simpson's rule for the first N-2 intervals with
-                a trapezoidal rule on the last interval.
-
-        'last' : Use Simpson's rule for the last N-2 intervals with a
-               trapezoidal rule on the first interval.
+    even : {'avg', 'first', 'last'}, optional
+        depreceted option for handling of arrays with an even number of points. This option ignored.   
 
     See Also
     --------


### PR DESCRIPTION
start improving the code for arrays with an even number of points that cannot be integrated using the Simspon's rule, and are currenctly done using the trapezium rule on a single interval. (issue #5618)
Not finished
